### PR TITLE
update to 4.2.0

### DIFF
--- a/recipe/bld-win.bat
+++ b/recipe/bld-win.bat
@@ -1,8 +1,12 @@
+@echo on
+
 :: Install cargo-license
 :: Set up rust environment
 set CARGO_HOME=%CONDA_PREFIX%\.cargo.win
 set CARGO_CONFIG=%CARGO_HOME%\config
 set RUSTUP_HOME=%CARGO_HOME%\rustup
+set CARGO_PROFILE_RELEASE_STRIP=symbols
+set CARGO_PROFILE_RELEASE_LTO=fat
 icacls %CARGO_HOME% /grant Users:F
 
 echo "Building %PKG_NAME%"
@@ -13,19 +17,13 @@ md %CD%\build-%PKG_NAME%
 set TEMP=%CD%\build-%PKG_NAME%
 
 :: Needed to bootstrap istelf into the conda ecosystem
-cargo install cargo-bundle-licenses
+cargo auditable install cargo-bundle-licenses
 :: Check that all downstream libraries licenses are present
 set PATH=%PATH%;%CARGO_HOME%\bin
 cargo bundle-licenses --format yaml --output CI.THIRDPARTY.yml --previous THIRDPARTY.yml --check-previous
 
 :: build
-cargo install --locked --root "%PREFIX%" --path . || goto :error
-
-:: strip debug symbols
-strip "%PREFIX%\bin\cargo-bundle-licenses.exe" || goto :error
-
-:: remove extra build file
-del /F /Q "%PREFIX%\.crates.toml"
+cargo auditable install --no-track --locked --root "%PREFIX%" --path . || goto :error
 
 goto :EOF
 

--- a/recipe/build-unix.sh
+++ b/recipe/build-unix.sh
@@ -6,6 +6,8 @@ set -o xtrace -o nounset -o pipefail -o errexit
 export CARGO_HOME=${CONDA_PREFIX}/.cargo.$(uname)
 export CARGO_CONFIG=${CARGO_HOME}/config
 export RUSTUP_HOME=${CARGO_HOME}/rustup
+export CARGO_PROFILE_RELEASE_STRIP=symbols
+export CARGO_PROFILE_RELEASE_LTO=fat
 
 # On macOS, reserve space so conda's install_name_tool can fix rpaths/install names later
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -13,10 +15,4 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 # build statically linked binary with Rust
-cargo install --verbose --locked --root "$PREFIX" --path .
-
-# strip debug symbols
-"$STRIP" "$PREFIX/bin/cargo-bundle-licenses"
-
-# remove extra build file
-rm -f "${PREFIX}/.crates.toml"
+cargo auditable install --no-track --verbose --locked --root "$PREFIX" --path .

--- a/recipe/build-unix.sh
+++ b/recipe/build-unix.sh
@@ -7,6 +7,11 @@ export CARGO_HOME=${CONDA_PREFIX}/.cargo.$(uname)
 export CARGO_CONFIG=${CARGO_HOME}/config
 export RUSTUP_HOME=${CARGO_HOME}/rustup
 
+# On macOS, reserve space so conda's install_name_tool can fix rpaths/install names later
+if [[ "$(uname)" == "Darwin" ]]; then
+  export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-headerpad_max_install_names"
+fi
+
 # build statically linked binary with Rust
 cargo install --verbose --locked --root "$PREFIX" --path .
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-rust_compiler_version:
-  - 1.64.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,9 @@ build:
 
 outputs:
   - name: {{ name }}
-    script: build-unix.sh  # [not win]
-    script: bld-win.bat  # [win]
+    script:
+      - build-unix.sh  # [not win]
+      - bld-win.bat    # [win]
     requirements:
       build:
         - {{ compiler('rust') }}
@@ -28,9 +29,9 @@ outputs:
         - pkg-config
         - cmake
         - libgit2
-      test:
-        commands:
-          - cargo-bundle-licenses --help
+    test:
+      commands:
+        - cargo-bundle-licenses --help
   - name: {{ name }}-gnu                    # [win]
     script: bld-win.bat                     # [win]
     requirements:                           # [win]
@@ -38,15 +39,16 @@ outputs:
         - rust-gnu_win-64                   # [win]
         - {{ compiler('rust-gnu') }}        # [win]
         - {{ compiler('c') }}               # [win]
+        - {{ stdlib('c') }}                 # [win]
         - {{ compiler('m2w64_c') }}         # [win]
         - cargo-auditable                   # [win]
         - pkg-config                        # [win]
-        - m2-make                           # [win]
+        - msys2-make                        # [win]
         - cmake                             # [win]
         - libgit2                           # [win]
-      test:                                 # [win]
-        commands:                           # [win]
-          - cargo-bundle-licenses --help    # [win]
+    test:                                 # [win]
+      commands:                           # [win]
+        - cargo-bundle-licenses --help    # [win]
 
 about:
   home: https://github.com/sstadick/cargo-bundle-licenses

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,8 @@ build:
 
 outputs:
   - name: {{ name }}
-    script:
-      - build-unix.sh  # [not win]
-      - bld-win.bat    # [win]
+    script: build-unix.sh  # [not win]
+    script: bld-win.bat  # [win]
     requirements:
       build:
         - {{ compiler('rust') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cargo-bundle-licenses" %}
-{% set version = "0.5.0" %}
-{% set sha256 = "c2c746cb46ed43ed06a34b961a8d71fc86387fd68103d42e34043e80d0fb3a30" %}
+{% set version = "4.2.0" %}
+{% set sha256 = "196d27676dae302d3c91315c1323b790f13b838b6dfd67b2f6c0236a55547765" %}
 
 package:
   name: {{ name }}-suite
@@ -14,8 +14,6 @@ build:
   number: 0
   ignore_run_exports:
     - libgit2
-  missing_dso_whitelist:
-    - $RPATH/ld64.so.1  # [s390x]
 
 outputs:
   - name: {{ name }}
@@ -23,13 +21,10 @@ outputs:
     script: bld-win.bat  # [win]
     requirements:
       build:
-        - rust_win-64  # [win]
-        - {{ compiler('m2w64_c') }} # [win]
-        - {{ compiler('rust') }}  # [not win]
-        - {{ compiler('c') }} # [not win]
+        - {{ compiler('rust') }}
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
         - pkg-config
-        - make  # [not win]
-        - m2-make # [win]
         - cmake
         - libgit2
       test:
@@ -40,6 +35,8 @@ outputs:
     requirements:                           # [win]
       build:                                # [win]
         - rust-gnu_win-64                   # [win]
+        - {{ compiler('rust-gnu') }}        # [win]
+        - {{ compiler('c') }}               # [win]
         - {{ compiler('m2w64_c') }}         # [win]
         - pkg-config                        # [win]
         - m2-make                           # [win]
@@ -58,7 +55,6 @@ about:
   description: A rust tool to bundle all third-party licenses into a single file.
   dev_url: https://github.com/sstadick/cargo-bundle-licenses
   doc_url: https://github.com/sstadick/cargo-bundle-licenses
-  doc_source_url: https://github.com/sstadick/cargo-bundle-licenses/blob/v{{ version }}/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ outputs:
         - {{ compiler('rust') }}
         - {{ compiler('c') }}
         - {{ stdlib('c') }}
+        - cargo-auditable
         - pkg-config
         - cmake
         - libgit2
@@ -38,6 +39,7 @@ outputs:
         - {{ compiler('rust-gnu') }}        # [win]
         - {{ compiler('c') }}               # [win]
         - {{ compiler('m2w64_c') }}         # [win]
+        - cargo-auditable                   # [win]
         - pkg-config                        # [win]
         - m2-make                           # [win]
         - cmake                             # [win]


### PR DESCRIPTION
cargo-bundle-licenses 4.2.0

**Destination channel:** main
### Links

- PKG-12941
- https://github.com/sstadick/cargo-bundle-licenses/tree/v4.2.0
