### PR TITLE
Add generated anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -2,6 +2,10 @@ anaconda_config_version: 1
 upstream_sources:
   - github:
       identifier: sstadick/cargo-bundle-licenses
+      use_max_tag: true
+      include_regex: ^v\d+\.\d+\.\d+$
+      from_pattern: ^v(.+)$
+      to_pattern: \1
     packages:
       - cargo-bundle-licenses
       - cargo-bundle-licenses-gnu


### PR DESCRIPTION
This PR adds generated `anaconda.yaml` (Feedstock Configuration Format).